### PR TITLE
Fixed algo type cast in constructor from (string) to (int)

### DIFF
--- a/Encoder/NativePasswordEncoder.php
+++ b/Encoder/NativePasswordEncoder.php
@@ -48,7 +48,7 @@ final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSalti
             throw new \InvalidArgumentException('$cost must be in the range of 4-31.');
         }
 
-        $this->algo = (string) ($algo ?? (\defined('PASSWORD_ARGON2ID') ? PASSWORD_ARGON2ID : (\defined('PASSWORD_ARGON2I') ? PASSWORD_ARGON2I : PASSWORD_BCRYPT)));
+        $this->algo = (int) ($algo ?? (\defined('PASSWORD_ARGON2ID') ? PASSWORD_ARGON2ID : (\defined('PASSWORD_ARGON2I') ? PASSWORD_ARGON2I : PASSWORD_BCRYPT)));
         $this->options = [
             'cost' => $cost,
             'time_cost' => $opsLimit,


### PR DESCRIPTION
password_hash takes int as $algo argument, it fixes error 500 when using FOSUserBundle